### PR TITLE
My changes to DexBuilder

### DIFF
--- a/dex_builder.cc
+++ b/dex_builder.cc
@@ -36,6 +36,7 @@
 #include "slicer/dex_format.h"
 #include "slicer/dex_ir.h"
 
+#include <array>
 #include <memory>
 
 namespace startop {
@@ -405,6 +406,14 @@ ir::EncodedMethod *MethodBuilder::Encode() {
             ? 0
             : 1;
     code->outs_count = std::max(return_count, max_args_);
+    if (class_->source_file) {
+      static constexpr auto kDebugInfo =
+          std::array{::dex::DBG_FIRST_SPECIAL, ::dex::DBG_END_SEQUENCE};
+      auto *debug_info = dex_file()->Alloc<ir::DebugInfo>();
+      debug_info->line_start = 0;
+      debug_info->data = slicer::MemView{kDebugInfo.data(), kDebugInfo.size()};
+      code->debug_info = debug_info;
+    }
     method->code = code;
   }
 

--- a/slicer/writer.cc
+++ b/slicer/writer.cc
@@ -991,6 +991,10 @@ void Writer::WriteTryBlocks(const ir::Code* irCode) {
 dex::u4 Writer::WriteCode(const ir::Code* irCode) {
   SLICER_CHECK(irCode != nullptr);
 
+  if (irCode->instructions.empty()) {
+      return 0;
+  }
+
   dex::Code dex_code = {};
   dex_code.registers_size = irCode->registers;
   dex_code.ins_size = irCode->ins_count;
@@ -1037,7 +1041,8 @@ void Writer::WriteEncodedMethod(const ir::EncodedMethod* ir_encoded_method,
   }
   *base_index = ir_encoded_method->decl->index;
 
-  dex::u4 code_offset = FilePointer(ir_encoded_method->code);
+  auto ir_code = ir_encoded_method->code;
+  dex::u4 code_offset = ir_code->instructions.empty() ? 0 : FilePointer(ir_code);
 
   auto& data = dex_->class_data;
   data.PushULeb128(index_delta);


### PR DESCRIPTION
* Implement native method generation
* Add basic debug info to show source file in stack traces

Previously, generated methods lacked line number information causing 
stack traces to always display `Unknown Source` instead of the actual 
source file. This change adds minimal debug information to properly 
display the source file name in exception stack traces.