### PR TITLE
Fix SIGSEGV caused by method not containing code when obfuscating dex

### DIFF
--- a/slicer/writer.cc
+++ b/slicer/writer.cc
@@ -1042,7 +1042,7 @@ void Writer::WriteEncodedMethod(const ir::EncodedMethod* ir_encoded_method,
   *base_index = ir_encoded_method->decl->index;
 
   auto ir_code = ir_encoded_method->code;
-  dex::u4 code_offset = ir_code->instructions.empty() ? 0 : FilePointer(ir_code);
+  dex::u4 code_offset = !ir_code || ir_code->instructions.empty() ? 0 : FilePointer(ir_code);
 
   auto& data = dex_->class_data;
   data.PushULeb128(index_delta);

--- a/slicer/writer.cc
+++ b/slicer/writer.cc
@@ -991,10 +991,6 @@ void Writer::WriteTryBlocks(const ir::Code* irCode) {
 dex::u4 Writer::WriteCode(const ir::Code* irCode) {
   SLICER_CHECK(irCode != nullptr);
 
-  if (irCode->instructions.empty()) {
-      return 0;
-  }
-
   dex::Code dex_code = {};
   dex_code.registers_size = irCode->registers;
   dex_code.ins_size = irCode->ins_count;
@@ -1041,8 +1037,7 @@ void Writer::WriteEncodedMethod(const ir::EncodedMethod* ir_encoded_method,
   }
   *base_index = ir_encoded_method->decl->index;
 
-  auto ir_code = ir_encoded_method->code;
-  dex::u4 code_offset = !ir_code || ir_code->instructions.empty() ? 0 : FilePointer(ir_code);
+  dex::u4 code_offset = FilePointer(ir_encoded_method->code);
 
   auto& data = dex_->class_data;
   data.PushULeb128(index_delta);


### PR DESCRIPTION
Revert my previous changes to writer.cc